### PR TITLE
Django 1.6 Update to savedqueries app

### DIFF
--- a/django_qbe/savedqueries/admin.py
+++ b/django_qbe/savedqueries/admin.py
@@ -2,9 +2,17 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.contrib import admin
 from django.contrib.admin.util import unquote
-from django.conf.urls import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    # Backward compatibility for Django prior to 1.6
+    from django.conf.urls.defaults import patterns, url
 from django.shortcuts import redirect
-from functools import update_wrapper
+try:
+    from functools import update_wrapper
+except ImportError:
+    # Backward compatibility for Django prior to 1.6
+    from django.utils.functional import update_wrapper
 
 from django_qbe.utils import pickle_encode, get_query_hash
 from django_qbe.utils import admin_site


### PR DESCRIPTION
This adds backward compatible fix for the saved queries app, import django.conf.urls in the admin pages
