### PR TITLE
Update mimetype -> content_type

### DIFF
--- a/django_qbe/exports.py
+++ b/django_qbe/exports.py
@@ -74,19 +74,19 @@ def base_export(labels, results, dialect=csv.excel_tab):
 @formats.add("csv")
 def csv_format(labels, results):
     output = base_export(labels, results, dialect=csv.excel)
-    mimetype = "text/csv"
-    return HttpResponse(output, mimetype=mimetype)
+    content_type = "text/csv"
+    return HttpResponse(output, content_type=content_type)
 
 
 @formats.add("ods")
 def ods_format(labels, results):
     output = base_export(labels, results)
-    mimetype = "application/vnd.oasis.opendocument.spreadsheet"
-    return HttpResponse(output, mimetype=mimetype)
+    content_type = "application/vnd.oasis.opendocument.spreadsheet"
+    return HttpResponse(output, content_type=content_type)
 
 
 @formats.add("xls")
 def xls_format(labels, results):
     output = base_export(labels, results)
-    mimetype = "application/vnd.ms-excel"
-    return HttpResponse(output, mimetype=mimetype)
+    content_type = "application/vnd.ms-excel"
+    return HttpResponse(output, content_type=content_type)

--- a/django_qbe/templates/qbe_results.html
+++ b/django_qbe/templates/qbe_results.html
@@ -37,7 +37,7 @@
         {% trans "Save query as" %}
     </li>
     <li>
-        <a href="{% url "qbe_bookmark" %}?data={{ pickled }}" title="{% trans "Drag this yo your bookmarks bar to save this query" %}" id="qbeBookmarkQuery">{% trans "bookmark" %}</a>
+        <a href="{% url "qbe_bookmark" %}?data={{ pickled }}" title="{% trans "Drag this to your bookmarks bar to save this query" %}" id="qbeBookmarkQuery">{% trans "bookmark" %}</a>
     </li>
     {% if savedqueries_installed %}
     <li>


### PR DESCRIPTION
mimetype deprecated/removed in Django 1.7, updating to content_type allows users to download exports (csv/xls) again

see https://github.com/django/django/commit/8eadbc5a03d06f5bfedfa3fad35ad0801d2ab6ff