### PR TITLE
Fixing certain filters

### DIFF
--- a/django_qbe/forms.py
+++ b/django_qbe/forms.py
@@ -183,6 +183,14 @@ class BaseQueryByExampleFormSet(BaseFormSet):
             group_by = data["group_by"]
             db_field = u"%s.%s" % (qn(model), qn(field))
             operator, over = criteria
+            olower = operator.lower()
+            if 'contains' in olower:
+                over = '%' + over + '%'
+            elif 'endswith' in olower:
+                over = '%' + over
+            elif 'startswith' in olower:
+                over = over + '%'
+
             is_join = operator.lower() == 'join'
             if show and not is_join:
                 selects.append(db_field)

--- a/django_qbe/widgets.py
+++ b/django_qbe/widgets.py
@@ -22,7 +22,7 @@ OPERATOR_CHOICES = (
     ('icontains', _('(i) contains')),
     ('iregex', _('(i) matchs regex')),
     ('istartswith', _('(i) starts with')),
-    ('endswith', _('(i) ends with')),
+    ('iendswith', _('(i) ends with')),
     ('join', _('joins to')),
 )
 


### PR DESCRIPTION
If you look at django.db.backends.mysql.base.DatabaseWrapper.operators in a terminal all the startswith and endswith operators are the same as their contains operators.

```
{u'contains': u'LIKE BINARY %s',
 u'endswith': u'LIKE BINARY %s',
 u'exact': u'= %s',
 u'gt': u'> %s',
 u'gte': u'>= %s',
 u'icontains': u'LIKE %s',
 u'iendswith': u'LIKE %s',
 u'iexact': u'LIKE %s',
 u'iregex': u'REGEXP %s',
 u'istartswith': u'LIKE %s',
 u'lt': u'< %s',
 u'lte': u'<= %s',
 u'regex': u'REGEXP BINARY %s',
 u'startswith': u'LIKE BINARY %s'}
```

You need to format the starts with and ends with to include a percent sign to act as a wildcard. Also there is a typo in widgets where iendswith is missing the i.