### PR TITLE
Fixed CSV export with Python 2

### DIFF
--- a/django_qbe/exports.py
+++ b/django_qbe/exports.py
@@ -5,7 +5,11 @@ from builtins import object
 # -*- coding: utf-8 -*-
 import codecs
 import csv
-from io import StringIO
+try:
+    # Use byte-oriented StringIO on Python 2!
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from django.http import HttpResponse
 from django.utils.datastructures import SortedDict


### PR DESCRIPTION
When exporting CSV under Python 2, I got the following error:
  File "/home/phil/build/myproject/env/lib/python2.7/site-packages/django_qbe/exports.py", line 56, in writerow
    self.writer.writerow([str(s).encode("utf-8") for s in row])
TypeError: unicode argument expected, got 'str'

because io.StringIO expects unicode. This patch fixes the problem under Python 2 keeping Python 3 behaviour intact. However, I am not sure if it (the CSV export) has ever been working under Python 3.
